### PR TITLE
Parse DateTime objects using Ruby

### DIFF
--- a/lib/snmp4jr.rb
+++ b/lib/snmp4jr.rb
@@ -55,6 +55,7 @@ module SNMP4JR
 end
 
 require 'snmp4jr/mib_manager'
+require 'snmp4jr/date_time_converter'
 require 'snmp4jr/variable_binding'
 require 'snmp4jr/message'
 require 'snmp4jr/trap_listener'

--- a/lib/snmp4jr/date_time_converter.rb
+++ b/lib/snmp4jr/date_time_converter.rb
@@ -1,0 +1,126 @@
+module SNMP4JR
+  # Utility class for converting SNMP DateTime octet strings into useful information.
+  #
+  # Example:
+  #
+  #   datetime = SnmpDateTimeConverter.new('07:e0:06:17:0d:18:01:00:2d:04:00')
+  #
+  #   datetime.to_s
+  #   => "2016-6-23,13:24:01.0,-4:0"
+  #
+  #   datetime.to_time
+  #   => 2016-06-23 13:24:01 -0400
+  #
+  #   datetime.to_time.to_i
+  #   => 1466702641
+  #
+  # SNMP DateTime specification:
+  #
+  # DateAndTime ::= TEXTUAL-CONVENTION
+  #     DISPLAY-HINT "2d-1d-1d,1d:1d:1d.1d,1a1d:1d"
+  #     STATUS       current
+  #     DESCRIPTION
+  #             "A date-time specification.
+  #
+  #             field  octets  contents                  range
+  #             -----  ------  --------                  -----
+  #               1      1-2   year*                     0..65536
+  #               2       3    month                     1..12
+  #               3       4    day                       1..31
+  #               4       5    hour                      0..23
+  #               5       6    minutes                   0..59
+  #               6       7    seconds                   0..60
+  #                            (use 60 for leap-second)
+  #               7       8    deci-seconds              0..9
+  #               8       9    direction from UTC        '+' / '-'
+  #               9      10    hours from UTC*           0..13
+  #              10      11    minutes from UTC          0..59
+  #
+  #             * Notes:
+  #             - the value of year is in network-byte order
+  #             - daylight saving time in New Zealand is +13
+  #
+  #             For example, Tuesday May 26, 1992 at 1:30:15 PM EDT would be
+  #             displayed as:
+  #
+  #                              1992-5-26,13:30:15.0,-4:0
+  #
+  #             Note that if only local time is known, then timezone
+  #             information (fields 8-10) is not present."
+  #     SYNTAX       OCTET STRING (SIZE (8 | 11))
+  #
+  class DateTimeConverter
+
+    SPLIT_TOKEN   = ':'
+
+    YEAR          = 0..1
+    MONTH         = 2
+    DAY           = 3
+    HOUR          = 4
+    MINUTES       = 5
+    SECONDS       = 6
+    DECI_SECONDS  = 7
+    UTC_DIRECTION = 8
+    UTC_HOURS     = 9
+    UTC_MINUTES   = 10
+
+    def initialize(string = '')
+      @string = string
+      parse
+    end
+
+    # 1992-5-26,13:30:15.0,-4:0
+    def to_s
+     [date, time, zone].join(',')
+    end
+
+    def to_time
+      Time.new(@year, @month, @day, @hour, @minutes, @seconds, formatted_zone)
+    end
+
+    def to_i
+      to_time.to_i
+    end
+
+    def date
+      "#{@year}-#{@month}-#{@day}"
+    end
+
+    def time
+      "#{padded(@hour)}:#{padded(@minutes)}:#{padded(@seconds)}.#{@deci_seconds}"
+    end
+
+    def zone
+      "#{@utc_direction}#{@utc_hours}:#{@utc_minutes}"
+    end
+
+    def octets
+      @octets ||= @string.split(SPLIT_TOKEN)
+    end
+
+    # "+HH:MM" or "-HH:MM" expected for ruby utc_offset
+    def formatted_zone
+      "#{@utc_direction}#{padded(@utc_hours)}:#{padded(@utc_minutes)}"
+    end
+
+    private
+
+    def parse
+      @year          = octets[YEAR].join.hex
+      @month         = octets[MONTH].hex
+      @day           = octets[DAY].hex
+      @hour          = octets[HOUR].hex
+      @minutes       = octets[MINUTES].hex
+      @seconds       = octets[SECONDS].hex
+      @deci_seconds  = octets[DECI_SECONDS].hex
+      @utc_direction = octets[UTC_DIRECTION].hex.chr
+      @utc_hours     = octets[UTC_HOURS].hex
+      @utc_minutes   = octets[UTC_MINUTES].hex
+    end
+
+    def padded(input)
+      sprintf '%02d', input
+    end
+
+  end
+end

--- a/lib/snmp4jr/variable_binding.rb
+++ b/lib/snmp4jr/variable_binding.rb
@@ -21,14 +21,8 @@ module SNMP4JR
     def format_smi_object
       # If we have a DateAndTime object, parse it into a usable format.
       if date_and_time_object?
-        date_and_time = SNMP4JR::SMI::OctetString.new(variable_binding.variable)
-
-        # Parse the SNMPv2-TC DateAndTime syntax into a datetime object.
-        # http://www.snmp4j.org/agent/doc/org/snmp4j/agent/mo/snmp/DateAndTime.html
-        calendar = SNMP4JR::Agent::MO::Snmp::DateAndTime.make_calendar(date_and_time)
-
-        # Convert datetime to Unix Epoch
-        @value = calendar.time_in_millis / 1000
+        date_and_time = variable_binding.variable.to_s
+        @value = SNMP4JR::DateTimeConverter.new(date_and_time).to_i
 
       # Addresses are (correctly) rendered like "ab:cd:ef:gh...",
       # we want "abcd:efgh...."

--- a/lib/snmp4jr/variable_binding.rb
+++ b/lib/snmp4jr/variable_binding.rb
@@ -13,14 +13,12 @@ module SNMP4JR
       @oid   = variable_binding.oid.to_s
       @value = variable_binding.variable.to_s
 
-      format_smi_object
+      format_smi_object if has_smi_syntax?
     end
 
     private
 
     def format_smi_object
-      return unless has_smi_syntax?
-
       # If we have a DateAndTime object, parse it into a usable format.
       if date_and_time_object?
         date_and_time = SNMP4JR::SMI::OctetString.new(variable_binding.variable)

--- a/lib/snmp4jr/variable_binding.rb
+++ b/lib/snmp4jr/variable_binding.rb
@@ -30,7 +30,7 @@ module SNMP4JR
         calendar = SNMP4JR::Agent::MO::Snmp::DateAndTime.make_calendar(date_and_time)
 
         # Convert datetime to Unix Epoch
-        @value = calendar.time_in_millis * 1000
+        @value = calendar.time_in_millis / 1000
 
       # Addresses are (correctly) rendered like "ab:cd:ef:gh...",
       # we want "abcd:efgh...."

--- a/lib/snmp4jr/variable_binding.rb
+++ b/lib/snmp4jr/variable_binding.rb
@@ -22,7 +22,7 @@ module SNMP4JR
       return unless has_smi_syntax?
 
       # If we have a DateAndTime object, parse it into a usable format.
-      if smi_syntax_clause == DATE_AND_TIME
+      if date_and_time_object?
         date_and_time = SNMP4JR::SMI::OctetString.new(variable_binding.variable)
 
         # Parse the SNMPv2-TC DateAndTime syntax into a datetime object.
@@ -34,9 +34,17 @@ module SNMP4JR
 
       # Addresses are (correctly) rendered like "ab:cd:ef:gh...",
       # we want "abcd:efgh...."
-      elsif smi_syntax_clause == IPV6_ADDRESS
+      elsif ipv6_address_object?
         @value = value.gsub(/(..):(..)/,'\1\2')
       end
+    end
+
+    def date_and_time_object?
+      smi_syntax_clause == DATE_AND_TIME
+    end
+
+    def ipv6_address_object?
+      smi_syntax_clause == IPV6_ADDRESS
     end
 
     def has_smi_syntax?

--- a/logstash-input-snmp4jtrap.gemspec
+++ b/logstash-input-snmp4jtrap.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = 'logstash-input-snmp4jtrap'
-  s.version       = '1.0.2'
+  s.version       = '1.1.0'
   s.authors       = ['Michael Zaccari']
   s.email         = ['michael.zaccari@accelerated.com']
 


### PR DESCRIPTION
This ensures that timezones are preserved when converting a `DateTime` object to a unix epoch
